### PR TITLE
Base fix

### DIFF
--- a/cube.ttl
+++ b/cube.ttl
@@ -1,4 +1,4 @@
-@base <http://localhost:8080/rdf-cube-schema-example/> .
+@base <http://example.org/rdf-cube-schema-example/> .
 
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix cube: <http://ns.bergnet.org/cube/> .

--- a/shape.ttl
+++ b/shape.ttl
@@ -1,4 +1,4 @@
-@base <http://localhost:8080/outdoors/> .
+@base <http://example.org/rdf-cube-schema-example/> .
 
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix cube: <http://ns.bergnet.org/cube/> .

--- a/validation/cube-shape.ttl
+++ b/validation/cube-shape.ttl
@@ -1,0 +1,44 @@
+@base <http://example.org/> .
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <http://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix cube: <http://ns.bergnet.org/cube/> .
+
+#
+# This is the bare minimal SHACL shape for validating a cube.
+# All cubes should pass this validation.
+#
+
+<CubeShape>
+    a sh:NodeShape ;
+    sh:targetClass cube:Cube ;
+    sh:property [
+        sh:path cube:observationSet ;
+        sh:minCount 1 ;
+        sh:node <ObservationSetShape> ;
+    ] ;
+    sh:property [
+        # optional, but recommended
+        sh:path cube:observationConstraint ;
+        sh:node <ObservationConstraintShape> 
+    ] .
+
+<ObservationSetShape>
+    a sh:NodeShape ;
+    sh:targetClass cube:ObservationSet ;
+    sh:property [
+        sh:path cube:observation ;
+        sh:minCount 1 ;
+    ] .
+
+<ObservationConstraintShape>
+    a sh:NodeShape ;
+    sh:targetClass cube:ObservationConstraint ;
+    sh:property [
+        # we assume at least one dimension, otherwise we would have an empty Observation/shape
+        sh:path sh:property ;
+        sh:minCount 1 ;
+    ] .

--- a/validation/cube-shape.ttl
+++ b/validation/cube-shape.ttl
@@ -40,7 +40,7 @@
     a sh:NodeShape ;
     sh:targetClass cube:ObservationConstraint ;
     sh:property [
-        # we assume at least 3 dimensions, otherwise we would have an empty Observation/shape
+        # we assume at least 3 dimensions, otherwise we would have an empty list of dimensions
         # one for cube:observedBy, one for rdf:type and at least one cube dimension
         sh:path sh:property ;
         sh:minCount 3 ;

--- a/validation/cube-shape.ttl
+++ b/validation/cube-shape.ttl
@@ -19,6 +19,7 @@
         sh:path cube:observationSet ;
         sh:minCount 1 ;
         sh:node <ObservationSetShape> ;
+        sh:message "Cube needs an observationSet"
     ] ;
     sh:property [
         # optional, but recommended
@@ -32,13 +33,16 @@
     sh:property [
         sh:path cube:observation ;
         sh:minCount 1 ;
+        sh:message "Cube needs at least one observation"
     ] .
 
 <ObservationConstraintShape>
     a sh:NodeShape ;
     sh:targetClass cube:ObservationConstraint ;
     sh:property [
-        # we assume at least one dimension, otherwise we would have an empty Observation/shape
+        # we assume at least 3 dimensions, otherwise we would have an empty Observation/shape
+        # one for cube:observedBy, one for rdf:type and at least one cube dimension
         sh:path sh:property ;
-        sh:minCount 1 ;
+        sh:minCount 3 ;
+        sh:message "CubeConstraint needs at least a certain amount of sh:properties"
     ] .

--- a/validation/cube-shape.ttl
+++ b/validation/cube-shape.ttl
@@ -38,7 +38,7 @@
 
 <ObservationConstraintShape>
     a sh:NodeShape ;
-    sh:targetClass cube:ObservationConstraint ;
+    sh:targetClass cube:Constraint ;
     sh:property [
         # we assume at least 3 dimensions, otherwise we would have an empty list of dimensions
         # one for cube:observedBy, one for rdf:type and at least one cube dimension


### PR DESCRIPTION
There were two different namespaces used for the cube & shape, resulting in a disconnected link for `cube:observationConstraint`. 