### PR TITLE
Fix base IRI which was different in cube  & shape

### DIFF
--- a/cube.ttl
+++ b/cube.ttl
@@ -1,4 +1,4 @@
-@base <http://localhost:8080/rdf-cube-schema-example/> .
+@base <http://example.org/rdf-cube-schema-example/> .
 
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix cube: <http://ns.bergnet.org/cube/> .

--- a/shape.ttl
+++ b/shape.ttl
@@ -1,4 +1,4 @@
-@base <http://localhost:8080/outdoors/> .
+@base <http://example.org/rdf-cube-schema-example/> .
 
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix cube: <http://ns.bergnet.org/cube/> .


### PR DESCRIPTION
We had two different namespaces and thus a disconnected `cube:observationConstraint`.