### PR TITLE
fix: show recursive results from nested nodes

### DIFF
--- a/bin/rdf-cube-schema.js
+++ b/bin/rdf-cube-schema.js
@@ -21,6 +21,11 @@ function validationResultToString (result) {
   return `${severity} of ${sourceConstraintComponent}: "${message}" with path ${path} at focus node ${focusNode} (source: ${sourceShape})`
 }
 
+function includeNestedResult(result) {
+  const nestedResult = Object.keys(result.detail).length ? result.detail .map(includeNestedResult).flat() : []
+  return [result].concat(nestedResult).flat()
+}
+
 program
   .command('validate cube shape')
   .action(async (args, [cubeFilePath, shapeFilePath]) => {
@@ -29,9 +34,11 @@ program
 
     const report = await validateCube(cube, shape)
 
+    const results = report.results.map(includeNestedResult)
+
     console.log(`cube validation ${report.conforms ? 'successful' : 'failed'}`)
 
-    for (const result of report.results) {
+    for (const result of results.flat()) {
       console.log(validationResultToString(result))
     }
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "debug": "^4.1.1",
     "rdf-ext": "^1.3.0",
     "rdf-utils-fs": "^2.1.0",
-    "rdf-validate-shacl": "^0.2.1"
+    "rdf-validate-shacl": "^0.4.3"
   },
   "devDependencies": {
     "chromium": "^3.0.3",


### PR DESCRIPTION
currently `./bin/rdf-cube-schema.js validate data.ttl constraint.ttl` only shows the results from the topmost nodes. 
to make use of the validation report results from subsequently nested nodes shall also display.

As always: review this PR critically. Feel free to take it or come up with an improved solution :-)

i.e. `./bin/rdf-cube-schema.js validate data/bad-nfi-shape.ttl validation/standalone-constraint-constraint.ttl` will leave the user with output
- without this PR
```
Violation of NodeConstraintComponent: "The constraints do not validate" with path <http://www.w3.org/ns/shacl#property> at focus node <https://environment.ld.admin.ch/foen/nfi/49-19-None-None/cube/1/shape/> (source: _:b47)
```

- with this PR
```
Violation of NodeConstraintComponent: "The constraints do not validate" with path <http://www.w3.org/ns/shacl#property> at focus node <https://environment.ld.admin.ch/foen/nfi/49-19-None-None/cube/1/shape/> (source: _:b47)
Violation of NodeConstraintComponent: "inHierarchy requires a conform nextInHierarchy" with path <https://cube.link/meta/nextInHierarchy> at focus node _:b30 (source: _:b87)
```

